### PR TITLE
Refacto puma-helper UI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,18 +4,19 @@ go 1.12
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
-	github.com/go-ole/go-ole v1.2.1 // indirect
+	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/shirou/gopsutil v2.18.10+incompatible
+	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/spf13/viper v1.2.1
+	github.com/struCoder/pidusage v0.1.2
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
 	golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869 // indirect
 	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
-github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
-github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
+github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -25,8 +25,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
-github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
+github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
@@ -48,6 +48,8 @@ github.com/spf13/viper v1.2.1/go.mod h1:P4AexN0a+C9tGAnUFNwDMYYZv3pjFuvmeiMyKRaN
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/struCoder/pidusage v0.1.2 h1:fFPTThlcWFQyizv3xKs5Lyq1lpG5lZ36arEGNhWz2Vs=
+github.com/struCoder/pidusage v0.1.2/go.mod h1:pWBlW3YuSwRl6h7R5KbvA4N8oOqe9LjaKW5CwT1SPjI=
 github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8 h1:RB0v+/pc8oMzPsN97aZYEwNuJ6ouRJ2uhjxemJ9zvrY=
 github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8/go.mod h1:IlWNj9v/13q7xFbaK4mbyzMNwrZLaWSHx/aibKIZuIg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/status/client.go
+++ b/pkg/status/client.go
@@ -34,4 +34,6 @@ var (
 	ExpandDetails bool
 
 	currentApp string
+
+	retrieveStatusError []string
 )

--- a/pkg/status/json.go
+++ b/pkg/status/json.go
@@ -65,4 +65,5 @@ type pumaStatusWorker struct {
 	CurrentPhase   int     `json:"current_phase"`
 	Uptime         int64   `json:"uptime"`
 	CPUTimes       int     `json:"cpu_times"`
+	Backlog        int     `json:"backlog"`
 }

--- a/pkg/status/json.go
+++ b/pkg/status/json.go
@@ -34,14 +34,23 @@ type pumaStatusApplication struct {
 }
 
 type pumaStatusStatePaths struct {
-	PumaStatePath       string             `json:"puma_state_path"`
-	BootedWorkers       int                `json:"booted_workers"`
-	AppCurrentPhase     int                `json:"app_current_phase"`
-	OldWorkers          int                `json:"old_workers"`
-	Workers             []pumaStatusWorker `json:"workers"`
-	TotalMaxThreads     int                `json:"total_max_threads"`
-	TotalCurrentThreads int                `json:"total_current_threads"`
-	MainPid             int                `json:"main_pid"`
+	PumaStatePath       string                  `json:"puma_state_path"`
+	BootedWorkers       int                     `json:"booted_workers"`
+	AppCurrentPhase     int                     `json:"app_current_phase"`
+	OldWorkers          int                     `json:"old_workers"`
+	Workers             []pumaStatusWorker      `json:"workers"`
+	TotalMaxThreads     int                     `json:"total_max_threads"`
+	TotalCurrentThreads int                     `json:"total_current_threads"`
+	MainPid             int                     `json:"main_pid"`
+	Padding             *pumaStatusStatePadding `json:"-"`
+}
+
+type pumaStatusStatePadding struct {
+	Pid      int
+	CPU      int
+	CPUTimes int
+	Memory   int
+	Uptime   int
 }
 
 type pumaStatusWorker struct {

--- a/pkg/status/json.go
+++ b/pkg/status/json.go
@@ -46,11 +46,10 @@ type pumaStatusStatePaths struct {
 }
 
 type pumaStatusStatePadding struct {
-	Pid      int
-	CPU      int
-	CPUTimes int
-	Memory   int
-	Uptime   int
+	Pid    int
+	CPU    int
+	Memory int
+	Uptime int
 }
 
 type pumaStatusWorker struct {
@@ -64,6 +63,5 @@ type pumaStatusWorker struct {
 	Memory         float64 `json:"memory"`
 	CurrentPhase   int     `json:"current_phase"`
 	Uptime         int64   `json:"uptime"`
-	CPUTimes       int     `json:"cpu_times"`
 	Backlog        int     `json:"backlog"`
 }

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -67,7 +67,6 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 	pad := *pstatuspath.Padding
 
 	padcpu := strconv.Itoa(pad.CPU)
-	padcput := strconv.Itoa(pad.CPUTimes)
 	padmem := strconv.Itoa(pad.Memory)
 	paduptime := strconv.Itoa(pad.Uptime)
 	padpid := strconv.Itoa(pad.Pid)
@@ -97,10 +96,9 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 				asciiThreadLoad(key.CurrentThreads, key.MaxThreads),
 				key.Backlog)
 
-			fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %"+padcput+"s\tUptime: %"+paduptime+"s\n",
+			fmt.Printf("  Phase: %s\tLast checkin: %s\tUptime: %"+paduptime+"s\n",
 				phase,
 				te,
-				timeElapsedFromSeconds(key.CPUTimes),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 
 		} else {

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -3,6 +3,7 @@ package status
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	version "github.com/dimelo/puma-helper/pkg/version"
@@ -59,25 +60,28 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) {
 			phase = Red(fmt.Sprintf("%d", key.CurrentPhase))
 		}
 
-		if !ExpandDetails {
-			lcheckin := Green(timeElapsed(key.LastCheckin))
-			if len(timeElapsed(key.LastCheckin)) >= 3 {
-				lcheckin = Brown(timeElapsed(key.LastCheckin))
-			}
+		te := timeElapsed(key.LastCheckin)
 
-			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sM Phase: %s Uptime: %s Threads: %s (Last checkin: %s)\n", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads), lcheckin)
+		if !ExpandDetails {
+			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sM Phase: %s Uptime: %s Threads: %s", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+
+			if len(te) >= 3 || !strings.Contains(te, "s") {
+				fmt.Printf(" %s", Brown("Last checkin: "+te))
+			}
+			fmt.Println()
+
 			continue
 		}
 
 		bootbtn := BgGreen(Bold("[UP]"))
 		if !key.IsBooted {
 			bootbtn = BgRed(Bold("[DOWN]"))
-			fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tLast checkin: %s\n", bootbtn, key.Pid, key.ID, timeElapsed(key.LastCheckin))
+			fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tLast checkin: %s\n", bootbtn, key.Pid, key.ID, te)
 			continue
 		}
 
 		fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sM\tActive threads: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
-		fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %s\tUptime: %s\n", phase, timeElapsed(key.LastCheckin), timeElapsedFromSeconds(key.CPUTimes), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
+		fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %s\tUptime: %s\n", phase, te, timeElapsedFromSeconds(key.CPUTimes), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 	}
 }
 

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -33,12 +33,12 @@ func (ps pumaStatusFinalOutput) printStatusApps() {
 			if ExpandDetails {
 				fmt.Printf("\n  -> File: %s\n", keypath.PumaStatePath)
 				fmt.Printf("  Booted workers: %d | PID: %d\n", keypath.BootedWorkers, keypath.MainPid)
-				fmt.Printf("  Current phase: %d | Old workers: %d | Active threads: %s\n\n", keypath.AppCurrentPhase, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
+				fmt.Printf("  Current phase: %d | Old workers: %d | Load: %s\n\n", keypath.AppCurrentPhase, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 			} else {
 				if keypath.OldWorkers > 0 {
-					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d (Old: %d) | Active threads: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
+					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d (Old: %d) | Load: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 				} else {
-					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d | Active threads: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
+					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d | Load: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 				}
 			}
 
@@ -63,7 +63,7 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) {
 		te := timeElapsed(key.LastCheckin)
 
 		if !ExpandDetails {
-			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sM Phase: %s Uptime: %s Threads: %s", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sM Phase: %s Uptime: %s Load: %s", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
 
 			if len(te) >= 3 || !strings.Contains(te, "s") {
 				fmt.Printf(" %s", Brown("Last checkin: "+te))
@@ -80,7 +80,7 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) {
 			continue
 		}
 
-		fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sM\tActive threads: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+		fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sM\tLoad: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
 		fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %s\tUptime: %s\n", phase, te, timeElapsedFromSeconds(key.CPUTimes), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 	}
 }

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -63,25 +63,29 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) {
 		te := timeElapsed(key.LastCheckin)
 
 		if !ExpandDetails {
-			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sM Phase: %s Uptime: %s Load: %s", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sM Uptime: %s Load: %s", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
 
 			if len(te) >= 3 || !strings.Contains(te, "s") {
-				fmt.Printf(" %s", Brown("Last checkin: "+te))
+				fmt.Printf(" %s", Red("Last checkin: "+te))
 			}
+
+			if key.CurrentPhase != currentPhase {
+				fmt.Printf(" %s", Red("Phase: "+string(key.CurrentPhase)))
+			}
+
 			fmt.Println()
 
-			continue
-		}
+		} else {
+			bootbtn := BgGreen(Bold("[UP]"))
+			if !key.IsBooted {
+				bootbtn = BgRed(Bold("[DOWN]"))
+				fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tLast checkin: %s\n", bootbtn, key.Pid, key.ID, te)
+				continue
+			}
 
-		bootbtn := BgGreen(Bold("[UP]"))
-		if !key.IsBooted {
-			bootbtn = BgRed(Bold("[DOWN]"))
-			fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tLast checkin: %s\n", bootbtn, key.Pid, key.ID, te)
-			continue
+			fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sM\tLoad: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+			fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %s\tUptime: %s\n", phase, te, timeElapsedFromSeconds(key.CPUTimes), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 		}
-
-		fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sM\tLoad: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
-		fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %s\tUptime: %s\n", phase, te, timeElapsedFromSeconds(key.CPUTimes), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 	}
 }
 

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -75,7 +75,7 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) error {
 				lcheckin = Brown(timeElapsed(key.LastCheckin))
 			}
 
-			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sMiB Phase: %s Uptime: %s Threads: %s (Last checkin: %s)\n", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads), lcheckin)
+			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sM Phase: %s Uptime: %s Threads: %s (Last checkin: %s)\n", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads), lcheckin)
 			continue
 		}
 
@@ -86,7 +86,7 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) error {
 			continue
 		}
 
-		fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sMiB\tActive threads: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+		fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sM\tActive threads: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
 		fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %s\tUptime: %s\n", phase, timeElapsed(key.LastCheckin), timeElapsedFromSeconds(key.CPUTimes), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 	}
 	return nil

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -103,12 +103,15 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 				timeElapsedFromSeconds(key.CPUTimes),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 		} else {
-			fmt.Printf(" └ %"+padpid+"d CPU Av: %"+padcpu+"s Mem: %"+padmem+"s Uptime: %"+paduptime+"s Load: %s Queue: %d",
+			fmt.Printf(" └ %"+padpid+"d CPU: %"+padcpu+"s Mem: %"+padmem+"s Uptime: %"+paduptime+"s Load: %s",
 				key.Pid, colorCPU(key.CPUPercent),
 				colorMemory(key.Memory),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)),
-				asciiThreadLoad(key.CurrentThreads, key.MaxThreads),
-				key.Backlog)
+				asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+
+			if key.Backlog > 0 {
+				fmt.Printf("Queue: %s", BgBrown(Bold(string(key.Backlog))))
+			}
 
 			if len(te) >= 3 || !strings.Contains(te, "s") {
 				fmt.Printf(" %s", Red("Last checkin: "+te))

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -23,14 +23,13 @@ func (ps pumaStatusFinalOutput) printStatusApps() {
 	for _, key := range ps.Application {
 		currentApp = key.Name
 
-		basetitle := fmt.Sprintf("-> %s application", currentApp)
 		if ExpandDetails {
-			fmt.Printf(basetitle + " | App root: " + key.RootPath)
-		}
-		if len(key.Description) == 0 {
-			fmt.Printf(basetitle)
+			fmt.Printf("-> %s application | App root: %s", currentApp, key.RootPath)
 		} else {
-			fmt.Printf(basetitle + " | About: " + key.Description)
+			fmt.Printf("%s application", currentApp)
+		}
+		if len(key.Description) > 0 {
+			fmt.Printf(" | About: %s", key.Description)
 		}
 
 		for _, keypath := range key.PumaStatePaths {
@@ -45,7 +44,7 @@ func (ps pumaStatusFinalOutput) printStatusApps() {
 					keypath.OldWorkers,
 					asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 			} else {
-				fmt.Printf("\n  %d (%s) | Load: %s\n",
+				fmt.Printf("\n%d (%s) | Load: %s\n",
 					keypath.MainPid,
 					keypath.PumaStatePath,
 					asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
@@ -81,24 +80,7 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 
 		te := timeElapsed(key.LastCheckin)
 
-		if !ExpandDetails {
-			fmt.Printf("└ %"+padpid+"d %"+padcpu+"s%% %"+padmem+"sM Uptime: %"+paduptime+"s Load: %s",
-				key.Pid, colorCPU(key.CPUPercent),
-				colorMemory(key.Memory),
-				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)),
-				asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
-
-			if len(te) >= 3 || !strings.Contains(te, "s") {
-				fmt.Printf(" %s", Red("Last checkin: "+te))
-			}
-
-			if key.CurrentPhase != currentPhase {
-				fmt.Printf(" %s", Red("Phase: "+string(key.CurrentPhase)))
-			}
-
-			fmt.Println()
-
-		} else {
+		if ExpandDetails {
 			bootbtn := BgGreen(Bold("[UP]"))
 			if !key.IsBooted {
 				bootbtn = BgRed(Bold("[DOWN]"))
@@ -119,6 +101,22 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 				te,
 				timeElapsedFromSeconds(key.CPUTimes),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
+		} else {
+			fmt.Printf(" └ %"+padpid+"d %"+padcpu+"s%% %"+padmem+"sM Uptime: %"+paduptime+"s Load: %s",
+				key.Pid, colorCPU(key.CPUPercent),
+				colorMemory(key.Memory),
+				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)),
+				asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+
+			if len(te) >= 3 || !strings.Contains(te, "s") {
+				fmt.Printf(" %s", Red("Last checkin: "+te))
+			}
+
+			if key.CurrentPhase != currentPhase {
+				fmt.Printf(" %s", Red("Phase: "+string(key.CurrentPhase)))
+			}
+
+			fmt.Println()
 		}
 	}
 }

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -88,13 +88,14 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 				continue
 			}
 
-			fmt.Printf("*  %s ~ PID %"+padpid+"d\tWorker ID %d\tCPU Average: %"+padcpu+"s%%\tMem: %"+padmem+"sM\tLoad: %s\n",
+			fmt.Printf("*  %s ~ PID %"+padpid+"d\tWorker ID %d\tCPU Average: %"+padcpu+"s%%\tMem: %"+padmem+"sM\tLoad: %s Queue: %d\n",
 				bootbtn,
 				key.Pid,
 				key.ID,
 				colorCPU(key.CPUPercent),
 				colorMemory(key.Memory),
-				asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+				asciiThreadLoad(key.CurrentThreads, key.MaxThreads),
+				key.Backlog)
 
 			fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %"+padcput+"s\tUptime: %"+paduptime+"s\n",
 				phase,
@@ -102,11 +103,12 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 				timeElapsedFromSeconds(key.CPUTimes),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 		} else {
-			fmt.Printf(" └ %"+padpid+"d %"+padcpu+"s%% %"+padmem+"sM Uptime: %"+paduptime+"s Load: %s",
+			fmt.Printf(" └ %"+padpid+"d CPU Av: %"+padcpu+"s Mem: %"+padmem+"s Uptime: %"+paduptime+"s Load: %s Queue: %d",
 				key.Pid, colorCPU(key.CPUPercent),
 				colorMemory(key.Memory),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)),
-				asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
+				asciiThreadLoad(key.CurrentThreads, key.MaxThreads),
+				key.Backlog)
 
 			if len(te) >= 3 || !strings.Contains(te, "s") {
 				fmt.Printf(" %s", Red("Last checkin: "+te))

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -41,9 +41,9 @@ func (ps pumaStatusFinalOutput) printStatusApps() error {
 				fmt.Printf("  Current phase: %d | Old workers: %d | Active threads: %s\n\n", keypath.AppCurrentPhase, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 			} else {
 				if keypath.OldWorkers > 0 {
-					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d (Old: %d) | Active threads: %s\n\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
+					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d (Old: %d) | Active threads: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 				} else {
-					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d | Active threads: %s\n\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
+					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d | Active threads: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 				}
 			}
 
@@ -75,7 +75,7 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) error {
 				lcheckin = Brown(timeElapsed(key.LastCheckin))
 			}
 
-			fmt.Printf("* %d [%d] CPU Av: %s%% CPU Times: %s Mem: %sMiB Phase: %s Uptime: %s Threads: %s (Last checkin: %s)\n", key.ID, key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads), lcheckin)
+			fmt.Printf("  └ %d CPU Av: %s%% CPU Times: %s Mem: %sMiB Phase: %s Uptime: %s Threads: %s (Last checkin: %s)\n", key.Pid, colorCPU(key.CPUPercent), timeElapsedFromSeconds(key.CPUTimes), colorMemory(key.Memory), phase, timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)), asciiThreadLoad(key.CurrentThreads, key.MaxThreads), lcheckin)
 			continue
 		}
 

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -7,21 +7,15 @@ import (
 
 	version "github.com/dimelo/puma-helper/pkg/version"
 	. "github.com/logrusorgru/aurora"
+	log "github.com/sirupsen/logrus"
 )
 
-func printStatusGlobalInformations() {
-	fmt.Println("---------- Global informations ----------")
-	if ExpandDetails {
-		fmt.Printf("Version: %s\n", version.Version)
-		fmt.Printf("Date: %s\n\n\n", time.Now().Format(time.RFC1123Z))
-		return
-	}
+func printStatusHeader() {
 	fmt.Printf("Version: %s | Date: %s\n\n", version.Version, time.Now().Format(time.RFC1123Z))
 }
 
 // printStatusApps print apps context one by one
-func (ps pumaStatusFinalOutput) printStatusApps() error {
-	fmt.Println("----------- Application groups -----------")
+func (ps pumaStatusFinalOutput) printStatusApps() {
 	line := 0
 
 	for _, key := range ps.Application {
@@ -47,9 +41,7 @@ func (ps pumaStatusFinalOutput) printStatusApps() error {
 				}
 			}
 
-			if err := printStatusWorkers(keypath.Workers, keypath.AppCurrentPhase); err != nil {
-				return err
-			}
+			printStatusWorkers(keypath.Workers, keypath.AppCurrentPhase)
 		}
 
 		if line < len(ps.Application)-1 {
@@ -57,12 +49,10 @@ func (ps pumaStatusFinalOutput) printStatusApps() error {
 			line++
 		}
 	}
-
-	return nil
 }
 
 // printStatusWorkers print workers status context of one app
-func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) error {
+func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) {
 	for _, key := range ps {
 		phase := Green(fmt.Sprintf("%d", key.CurrentPhase))
 		if key.CurrentPhase != currentPhase {
@@ -89,7 +79,16 @@ func printStatusWorkers(ps []pumaStatusWorker, currentPhase int) error {
 		fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tCPU Average: %s%%\tMem: %sM\tActive threads: %s\n", bootbtn, key.Pid, key.ID, colorCPU(key.CPUPercent), colorMemory(key.Memory), asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
 		fmt.Printf("  Phase: %s\tLast checkin: %s\tTotal CPU times: %s\tUptime: %s\n", phase, timeElapsed(key.LastCheckin), timeElapsedFromSeconds(key.CPUTimes), timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
 	}
-	return nil
+}
+
+func printRetrieveStatusError() {
+	for k, v := range retrieveStatusError {
+		if k == 0 {
+			fmt.Println()
+		}
+
+		log.Warn(v)
+	}
 }
 
 // printAndBuildJSON marshal and print pumaStatusFinalOutput struct

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -73,17 +73,17 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 	padpid := strconv.Itoa(pad.Pid)
 
 	for _, key := range ps {
-		phase := Green(fmt.Sprintf("%d", key.CurrentPhase))
+		phase := Green(fmt.Sprintf("%d", key.CurrentPhase)).String()
 		if key.CurrentPhase != currentPhase {
-			phase = Red(fmt.Sprintf("%d", key.CurrentPhase))
+			phase = Red(fmt.Sprintf("%d", key.CurrentPhase)).String()
 		}
 
 		te := timeElapsed(key.LastCheckin)
 
 		if ExpandDetails {
-			bootbtn := BgGreen(Bold("[UP]"))
+			bootbtn := BgGreen(Bold("[UP]")).String()
 			if !key.IsBooted {
-				bootbtn = BgRed(Bold("[DOWN]"))
+				bootbtn = BgRed(Bold("[DOWN]")).String()
 				fmt.Printf("*  %s ~ PID %d\tWorker ID %d\tLast checkin: %s\n", bootbtn, key.Pid, key.ID, te)
 				continue
 			}
@@ -102,7 +102,9 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 				te,
 				timeElapsedFromSeconds(key.CPUTimes),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)))
+
 		} else {
+
 			fmt.Printf(" └ %"+padpid+"d CPU: %"+padcpu+"s Mem: %"+padmem+"s Uptime: %"+paduptime+"s Load: %s",
 				key.Pid, colorCPU(key.CPUPercent),
 				colorMemory(key.Memory),
@@ -110,15 +112,15 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 				asciiThreadLoad(key.CurrentThreads, key.MaxThreads))
 
 			if key.Backlog > 0 {
-				fmt.Printf("Queue: %s", BgBrown(Bold(string(key.Backlog))))
+				fmt.Printf(" %s", Red("Queue: "+string(key.Backlog)).String())
 			}
 
 			if len(te) >= 3 || !strings.Contains(te, "s") {
-				fmt.Printf(" %s", Red("Last checkin: "+te))
+				fmt.Printf(" %s", Red("Last checkin: "+te).String())
 			}
 
 			if key.CurrentPhase != currentPhase {
-				fmt.Printf(" %s", Red("Phase: "+string(key.CurrentPhase)))
+				fmt.Printf(" %s", Red("Phase: "+string(key.CurrentPhase)).String())
 			}
 
 			fmt.Println()

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -35,11 +35,7 @@ func (ps pumaStatusFinalOutput) printStatusApps() {
 				fmt.Printf("  Booted workers: %d | PID: %d\n", keypath.BootedWorkers, keypath.MainPid)
 				fmt.Printf("  Current phase: %d | Old workers: %d | Load: %s\n\n", keypath.AppCurrentPhase, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 			} else {
-				if keypath.OldWorkers > 0 {
-					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d (Old: %d) | Load: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, keypath.OldWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
-				} else {
-					fmt.Printf("\n-> %d (%s) Phase: %d | Workers: %d | Load: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, keypath.BootedWorkers, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
-				}
+				fmt.Printf("\n-> %d (%s) Phase: %d | Load: %s\n", keypath.MainPid, keypath.PumaStatePath, keypath.AppCurrentPhase, asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 			}
 
 			printStatusWorkers(keypath.Workers, keypath.AppCurrentPhase)

--- a/pkg/status/print.go
+++ b/pkg/status/print.go
@@ -23,7 +23,10 @@ func (ps pumaStatusFinalOutput) printStatusApps() {
 	for _, key := range ps.Application {
 		currentApp = key.Name
 
-		basetitle := fmt.Sprintf("-> %s application | App root: %s", currentApp, key.RootPath)
+		basetitle := fmt.Sprintf("-> %s application", currentApp)
+		if ExpandDetails {
+			fmt.Printf(basetitle + " | App root: " + key.RootPath)
+		}
 		if len(key.Description) == 0 {
 			fmt.Printf(basetitle)
 		} else {
@@ -42,10 +45,9 @@ func (ps pumaStatusFinalOutput) printStatusApps() {
 					keypath.OldWorkers,
 					asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 			} else {
-				fmt.Printf("\n-> %d (%s) Phase: %d | Load: %s\n",
+				fmt.Printf("\n  %d (%s) | Load: %s\n",
 					keypath.MainPid,
 					keypath.PumaStatePath,
-					keypath.AppCurrentPhase,
 					asciiThreadLoad(keypath.TotalCurrentThreads, keypath.TotalMaxThreads))
 			}
 
@@ -80,9 +82,8 @@ func printStatusWorkers(pstatuspath pumaStatusStatePaths, currentPhase int) {
 		te := timeElapsed(key.LastCheckin)
 
 		if !ExpandDetails {
-			fmt.Printf("  └ %"+padpid+"d CPU Av: %"+padcpu+"s%% CPU Times: %"+padcput+"s Mem: %"+padmem+"sM Uptime: %"+paduptime+"s Load: %s",
+			fmt.Printf("└ %"+padpid+"d %"+padcpu+"s%% %"+padmem+"sM Uptime: %"+paduptime+"s Load: %s",
 				key.Pid, colorCPU(key.CPUPercent),
-				timeElapsedFromSeconds(key.CPUTimes),
 				colorMemory(key.Memory),
 				timeElapsed(time.Unix(key.Uptime, 0).Format(time.RFC3339)),
 				asciiThreadLoad(key.CurrentThreads, key.MaxThreads))

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -107,6 +107,10 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 				workers = append(workers, worker)
 			}
 
+			sort.Slice(workers, func(i, j int) bool {
+				return workers[i].Uptime < workers[j].Uptime
+			})
+
 			pssp := pumaStatusStatePaths{
 				PumaStatePath:       pspath[fid],
 				BootedWorkers:       ps.BootedWorkers,

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 )
 
 // RunStatus run all status logical command
@@ -59,6 +60,7 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 
 		for fid, ps := range pss {
 
+			psspadding := pumaStatusStatePadding{}
 			workers := []pumaStatusWorker{}
 			tmthreads := 0
 			tcthreads := 0
@@ -70,21 +72,42 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 				if err != nil {
 					return nil, err
 				}
+				cpupadding := len(fmt.Sprintf("%.0f", cpu))
 
 				cput, err := getCPUTimesFromPID(pid)
 				if err != nil {
 					return nil, err
 				}
+				cputpading := len(timeElapsedFromSeconds(cput))
 
 				mem, err := getMemoryFromPID(pid)
 				if err != nil {
 					return nil, err
 				}
+				mempadding := len(fmt.Sprintf("%.0f", mem))
 
 				// Assuming this timestamp is in milliseconds
 				utime, err := getTotalUptimeFromPID(pid)
 				if err != nil {
 					return nil, err
+				}
+				utimepadding := len(timeElapsed(time.Unix(utime/1000, 0).Format(time.RFC3339)))
+
+				// Define padding used to print elements
+				if psspadding.CPU < cpupadding {
+					psspadding.CPU = cpupadding
+				}
+
+				if psspadding.CPUTimes < cputpading {
+					psspadding.CPUTimes = cputpading
+				}
+
+				if psspadding.Memory < mempadding {
+					psspadding.Memory = mempadding
+				}
+
+				if psspadding.Uptime < utimepadding {
+					psspadding.Uptime = utimepadding
 				}
 
 				worker := pumaStatusWorker{
@@ -119,6 +142,7 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 				TotalMaxThreads:     tmthreads,
 				MainPid:             ps.MainPid,
 				AppCurrentPhase:     ps.Phase,
+				Padding:             &psspadding,
 			}
 
 			pssps = append(pssps, pssp)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -122,6 +122,7 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 					CurrentPhase:   v.Phase,
 					Uptime:         utime / 1000,
 					CPUTimes:       cput,
+					Backlog:        v.LastStatus.Backlog,
 				}
 
 				tcthreads += (v.LastStatus.MaxThreads - v.LastStatus.PoolCapacity)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -66,24 +66,13 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 			tcthreads := 0
 
 			for _, v := range ps.WorkerStatus {
-				pid := int32(v.Pid)
+				pid := v.Pid
 
-				cpu, err := getCPUPercentFromPID(pid)
+				cpu, mem, err := getCPUPercentMemoryFromPID(pid)
 				if err != nil {
 					return nil, err
 				}
-				cpupadding := len(fmt.Sprintf("%.0f", cpu))
-
-				cput, err := getCPUTimesFromPID(pid)
-				if err != nil {
-					return nil, err
-				}
-				cputpading := len(timeElapsedFromSeconds(cput))
-
-				mem, err := getMemoryFromPID(pid)
-				if err != nil {
-					return nil, err
-				}
+				cpupadding := len(fmt.Sprintf("%.1f", cpu))
 				mempadding := len(fmt.Sprintf("%.0f", mem))
 
 				// Assuming this timestamp is in milliseconds
@@ -96,10 +85,6 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 				// Define padding used to print elements
 				if psspadding.CPU < cpupadding {
 					psspadding.CPU = cpupadding
-				}
-
-				if psspadding.CPUTimes < cputpading {
-					psspadding.CPUTimes = cputpading
 				}
 
 				if psspadding.Memory < mempadding {
@@ -121,7 +106,6 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 					Memory:         mem,
 					CurrentPhase:   v.Phase,
 					Uptime:         utime / 1000,
-					CPUTimes:       cput,
 					Backlog:        v.LastStatus.Backlog,
 				}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // RunStatus run all status logical command
@@ -19,9 +17,11 @@ func RunStatus() error {
 		return rsd.printAndBuildJSON()
 	}
 
-	printStatusGlobalInformations()
+	printStatusHeader()
+	rsd.printStatusApps()
+	printRetrieveStatusError()
 
-	return rsd.printStatusApps()
+	return nil
 }
 
 // retrieveStatusData fetch all data from Puma instances/workers
@@ -51,7 +51,7 @@ func retrieveStatusData() (*pumaStatusFinalOutput, error) {
 
 		pss, err := readPumaStats(pspath)
 		if err != nil {
-			log.Warn(fmt.Sprintf("[%s] configuration is invalid. Error: %v\n\n", appName, err))
+			retrieveStatusError = append(retrieveStatusError, fmt.Sprintf("[%s] configuration is invalid. Error: %v", appName, err))
 			continue
 		}
 

--- a/pkg/status/utils.go
+++ b/pkg/status/utils.go
@@ -193,5 +193,5 @@ func colorMemory(memory float64) string {
 		mcritical = 1000
 	}
 
-	return colorState(memory, float64(mwarn), float64(mcritical), fmt.Sprintf("%.1f", memory))
+	return colorState(memory, float64(mwarn), float64(mcritical), fmt.Sprintf("%.0f", memory))
 }

--- a/pkg/status/utils.go
+++ b/pkg/status/utils.go
@@ -134,7 +134,7 @@ func timeElapsed(nT string) string {
 
 	elapsed := time.Since(tx).String()
 	if strings.Contains(elapsed, "ms") {
-		return "~0s"
+		return "0s"
 	}
 
 	return fmt.Sprintf("%ss", strings.Split(elapsed, ".")[0])

--- a/vendor/github.com/StackExchange/wmi/swbemservices.go
+++ b/vendor/github.com/StackExchange/wmi/swbemservices.go
@@ -77,7 +77,7 @@ func (s *SWbemServices) process(initError chan error) {
 	//fmt.Println("process: starting background thread initialization")
 	//All OLE/WMI calls must happen on the same initialized thead, so lock this goroutine
 	runtime.LockOSThread()
-	defer runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	if err != nil {

--- a/vendor/github.com/StackExchange/wmi/wmi.go
+++ b/vendor/github.com/StackExchange/wmi/wmi.go
@@ -285,6 +285,10 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 		}
 		defer prop.Clear()
 
+		if prop.VT == 0x1 { //VT_NULL
+			continue
+		}
+
 		switch val := prop.Value().(type) {
 		case int8, int16, int32, int64, int:
 			v := reflect.ValueOf(val).Int()
@@ -383,7 +387,7 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 						}
 						f.Set(fArr)
 					}
-				case reflect.Uint8:
+				case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
 					safeArray := prop.ToArray()
 					if safeArray != nil {
 						arr := safeArray.ToValueArray()
@@ -391,6 +395,17 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 						for i, v := range arr {
 							s := fArr.Index(i)
 							s.SetUint(reflect.ValueOf(v).Uint())
+						}
+						f.Set(fArr)
+					}
+				case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+					safeArray := prop.ToArray()
+					if safeArray != nil {
+						arr := safeArray.ToValueArray()
+						fArr := reflect.MakeSlice(f.Type(), len(arr), len(arr))
+						for i, v := range arr {
+							s := fArr.Index(i)
+							s.SetInt(reflect.ValueOf(v).Int())
 						}
 						f.Set(fArr)
 					}

--- a/vendor/github.com/go-ole/go-ole/.travis.yml
+++ b/vendor/github.com/go-ole/go-ole/.travis.yml
@@ -2,8 +2,7 @@ language: go
 sudo: false
 
 go:
-  - 1.1
-  - 1.2
-  - 1.3
-  - 1.4
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip

--- a/vendor/github.com/go-ole/go-ole/README.md
+++ b/vendor/github.com/go-ole/go-ole/README.md
@@ -1,4 +1,4 @@
-#Go OLE
+# Go OLE
 
 [![Build status](https://ci.appveyor.com/api/projects/status/qr0u2sf7q43us9fj?svg=true)](https://ci.appveyor.com/project/jacobsantos/go-ole-jgs28)
 [![Build Status](https://travis-ci.org/go-ole/go-ole.svg?branch=master)](https://travis-ci.org/go-ole/go-ole)
@@ -35,12 +35,12 @@ AppVeyor is used to build on Windows using the (in-development) test COM server.
 
 The tests currently do run and do pass and this should be maintained with commits.
 
-##Versioning
+## Versioning
 
 Go OLE uses [semantic versioning](http://semver.org) for version numbers, which is similar to the version contract of the Go language. Which means that the major version will always maintain backwards compatibility with minor versions. Minor versions will only add new additions and changes. Fixes will always be in patch. 
 
 This contract should allow you to upgrade to new minor and patch versions without breakage or modifications to your existing code. Leave a ticket, if there is breakage, so that it could be fixed.
 
-##LICENSE
+## LICENSE
 
 Under the MIT License: http://mattn.mit-license.org/2013

--- a/vendor/github.com/go-ole/go-ole/com.go
+++ b/vendor/github.com/go-ole/go-ole/com.go
@@ -3,9 +3,7 @@
 package ole
 
 import (
-	"errors"
 	"syscall"
-	"time"
 	"unicode/utf16"
 	"unsafe"
 )
@@ -21,6 +19,7 @@ var (
 	procStringFromCLSID, _         = modole32.FindProc("StringFromCLSID")
 	procStringFromIID, _           = modole32.FindProc("StringFromIID")
 	procIIDFromString, _           = modole32.FindProc("IIDFromString")
+	procCoGetObject, _             = modole32.FindProc("CoGetObject")
 	procGetUserDefaultLCID, _      = modkernel32.FindProc("GetUserDefaultLCID")
 	procCopyMemory, _              = modkernel32.FindProc("RtlMoveMemory")
 	procVariantInit, _             = modoleaut32.FindProc("VariantInit")
@@ -209,6 +208,32 @@ func GetActiveObject(clsid *GUID, iid *GUID) (unk *IUnknown, err error) {
 	return
 }
 
+type BindOpts struct {
+	CbStruct          uint32
+	GrfFlags          uint32
+	GrfMode           uint32
+	TickCountDeadline uint32
+}
+
+// GetObject retrieves pointer to active object.
+func GetObject(programID string, bindOpts *BindOpts, iid *GUID) (unk *IUnknown, err error) {
+	if bindOpts != nil {
+		bindOpts.CbStruct = uint32(unsafe.Sizeof(BindOpts{}))
+	}
+	if iid == nil {
+		iid = IID_IUnknown
+	}
+	hr, _, _ := procCoGetObject.Call(
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(programID))),
+		uintptr(unsafe.Pointer(bindOpts)),
+		uintptr(unsafe.Pointer(iid)),
+		uintptr(unsafe.Pointer(&unk)))
+	if hr != 0 {
+		err = NewError(hr)
+	}
+	return
+}
+
 // VariantInit initializes variant.
 func VariantInit(v *VARIANT) (err error) {
 	hr, _, _ := procVariantInit.Call(uintptr(unsafe.Pointer(v)))
@@ -316,14 +341,4 @@ func DispatchMessage(msg *Msg) (ret int32) {
 	r0, _, _ := procDispatchMessageW.Call(uintptr(unsafe.Pointer(msg)))
 	ret = int32(r0)
 	return
-}
-
-// GetVariantDate converts COM Variant Time value to Go time.Time.
-func GetVariantDate(value float64) (time.Time, error) {
-	var st syscall.Systemtime
-	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(value), uintptr(unsafe.Pointer(&st)))
-	if r != 0 {
-		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
-	}
-	return time.Now(), errors.New("Could not convert to time, passing current time.")
 }

--- a/vendor/github.com/go-ole/go-ole/com_func.go
+++ b/vendor/github.com/go-ole/go-ole/com_func.go
@@ -169,6 +169,6 @@ func DispatchMessage(msg *Msg) int32 {
 	return int32(0)
 }
 
-func GetVariantDate(value float64) (time.Time, error) {
+func GetVariantDate(value uint64) (time.Time, error) {
 	return time.Now(), NewError(E_NOTIMPL)
 }

--- a/vendor/github.com/go-ole/go-ole/go.mod
+++ b/vendor/github.com/go-ole/go-ole/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-ole/go-ole
+
+go 1.12

--- a/vendor/github.com/go-ole/go-ole/idispatch_windows.go
+++ b/vendor/github.com/go-ole/go-ole/idispatch_windows.go
@@ -3,6 +3,7 @@
 package ole
 
 import (
+	"math/big"
 	"syscall"
 	"time"
 	"unsafe"
@@ -132,6 +133,8 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 				vargs[n] = NewVariant(VT_R8, *(*int64)(unsafe.Pointer(&vv)))
 			case *float64:
 				vargs[n] = NewVariant(VT_R8|VT_BYREF, int64(uintptr(unsafe.Pointer(v.(*float64)))))
+			case *big.Int:
+				vargs[n] = NewVariant(VT_DECIMAL, v.(*big.Int).Int64())
 			case string:
 				vargs[n] = NewVariant(VT_BSTR, int64(uintptr(unsafe.Pointer(SysAllocStringLen(v.(string))))))
 			case *string:

--- a/vendor/github.com/go-ole/go-ole/safearray_func.go
+++ b/vendor/github.com/go-ole/go-ole/safearray_func.go
@@ -124,12 +124,12 @@ func safeArrayGetElementSize(safearray *SafeArray) (*uint32, error) {
 }
 
 // safeArrayGetElement retrieves element at given index.
-func safeArrayGetElement(safearray *SafeArray, index int64, pv unsafe.Pointer) error {
+func safeArrayGetElement(safearray *SafeArray, index int32, pv unsafe.Pointer) error {
 	return NewError(E_NOTIMPL)
 }
 
 // safeArrayGetElement retrieves element at given index and converts to string.
-func safeArrayGetElementString(safearray *SafeArray, index int64) (string, error) {
+func safeArrayGetElementString(safearray *SafeArray, index int32) (string, error) {
 	return "", NewError(E_NOTIMPL)
 }
 
@@ -146,8 +146,8 @@ func safeArrayGetIID(safearray *SafeArray) (*GUID, error) {
 // multidimensional array.
 //
 // AKA: SafeArrayGetLBound in Windows API.
-func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (int64, error) {
-	return int64(0), NewError(E_NOTIMPL)
+func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (int32, error) {
+	return int32(0), NewError(E_NOTIMPL)
 }
 
 // safeArrayGetUBound returns upper bounds of SafeArray.
@@ -156,8 +156,8 @@ func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (int64, error) {
 // multidimensional array.
 //
 // AKA: SafeArrayGetUBound in Windows API.
-func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (int64, error) {
-	return int64(0), NewError(E_NOTIMPL)
+func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (int32, error) {
+	return int32(0), NewError(E_NOTIMPL)
 }
 
 // safeArrayGetVartype returns data type of SafeArray.

--- a/vendor/github.com/go-ole/go-ole/safearray_windows.go
+++ b/vendor/github.com/go-ole/go-ole/safearray_windows.go
@@ -205,7 +205,7 @@ func safeArrayGetElementSize(safearray *SafeArray) (length *uint32, err error) {
 }
 
 // safeArrayGetElement retrieves element at given index.
-func safeArrayGetElement(safearray *SafeArray, index int64, pv unsafe.Pointer) error {
+func safeArrayGetElement(safearray *SafeArray, index int32, pv unsafe.Pointer) error {
 	return convertHresultToError(
 		procSafeArrayGetElement.Call(
 			uintptr(unsafe.Pointer(safearray)),
@@ -214,7 +214,7 @@ func safeArrayGetElement(safearray *SafeArray, index int64, pv unsafe.Pointer) e
 }
 
 // safeArrayGetElementString retrieves element at given index and converts to string.
-func safeArrayGetElementString(safearray *SafeArray, index int64) (str string, err error) {
+func safeArrayGetElementString(safearray *SafeArray, index int32) (str string, err error) {
 	var element *int16
 	err = convertHresultToError(
 		procSafeArrayGetElement.Call(
@@ -243,7 +243,7 @@ func safeArrayGetIID(safearray *SafeArray) (guid *GUID, err error) {
 // multidimensional array.
 //
 // AKA: SafeArrayGetLBound in Windows API.
-func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (lowerBound int64, err error) {
+func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (lowerBound int32, err error) {
 	err = convertHresultToError(
 		procSafeArrayGetLBound.Call(
 			uintptr(unsafe.Pointer(safearray)),
@@ -258,7 +258,7 @@ func safeArrayGetLBound(safearray *SafeArray, dimension uint32) (lowerBound int6
 // multidimensional array.
 //
 // AKA: SafeArrayGetUBound in Windows API.
-func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (upperBound int64, err error) {
+func safeArrayGetUBound(safearray *SafeArray, dimension uint32) (upperBound int32, err error) {
 	err = convertHresultToError(
 		procSafeArrayGetUBound.Call(
 			uintptr(unsafe.Pointer(safearray)),

--- a/vendor/github.com/go-ole/go-ole/safearrayconversion.go
+++ b/vendor/github.com/go-ole/go-ole/safearrayconversion.go
@@ -14,7 +14,7 @@ func (sac *SafeArrayConversion) ToStringArray() (strings []string) {
 	totalElements, _ := sac.TotalElements(0)
 	strings = make([]string, totalElements)
 
-	for i := int64(0); i < totalElements; i++ {
+	for i := int32(0); i < totalElements; i++ {
 		strings[int32(i)], _ = safeArrayGetElementString(sac.Array, i)
 	}
 
@@ -25,7 +25,7 @@ func (sac *SafeArrayConversion) ToByteArray() (bytes []byte) {
 	totalElements, _ := sac.TotalElements(0)
 	bytes = make([]byte, totalElements)
 
-	for i := int64(0); i < totalElements; i++ {
+	for i := int32(0); i < totalElements; i++ {
 		safeArrayGetElement(sac.Array, i, unsafe.Pointer(&bytes[int32(i)]))
 	}
 
@@ -37,59 +37,59 @@ func (sac *SafeArrayConversion) ToValueArray() (values []interface{}) {
 	values = make([]interface{}, totalElements)
 	vt, _ := safeArrayGetVartype(sac.Array)
 
-	for i := 0; i < int(totalElements); i++ {
+	for i := int32(0); i < totalElements; i++ {
 		switch VT(vt) {
 		case VT_BOOL:
 			var v bool
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I1:
 			var v int8
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I2:
 			var v int16
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I4:
 			var v int32
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_I8:
 			var v int64
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI1:
 			var v uint8
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI2:
 			var v uint16
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI4:
 			var v uint32
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_UI8:
 			var v uint64
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_R4:
 			var v float32
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_R8:
 			var v float64
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_BSTR:
 			var v string
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v
 		case VT_VARIANT:
 			var v VARIANT
-			safeArrayGetElement(sac.Array, int64(i), unsafe.Pointer(&v))
+			safeArrayGetElement(sac.Array, i, unsafe.Pointer(&v))
 			values[i] = v.Value()
 		default:
 			// TODO
@@ -111,14 +111,14 @@ func (sac *SafeArrayConversion) GetSize() (length *uint32, err error) {
 	return safeArrayGetElementSize(sac.Array)
 }
 
-func (sac *SafeArrayConversion) TotalElements(index uint32) (totalElements int64, err error) {
+func (sac *SafeArrayConversion) TotalElements(index uint32) (totalElements int32, err error) {
 	if index < 1 {
 		index = 1
 	}
 
 	// Get array bounds
-	var LowerBounds int64
-	var UpperBounds int64
+	var LowerBounds int32
+	var UpperBounds int32
 
 	LowerBounds, err = safeArrayGetLBound(sac.Array, index)
 	if err != nil {

--- a/vendor/github.com/go-ole/go-ole/variant.go
+++ b/vendor/github.com/go-ole/go-ole/variant.go
@@ -88,10 +88,10 @@ func (v *VARIANT) Value() interface{} {
 		return v.ToString()
 	case VT_DATE:
 		// VT_DATE type will either return float64 or time.Time.
-		d := float64(v.Val)
+		d := uint64(v.Val)
 		date, err := GetVariantDate(d)
 		if err != nil {
-			return d
+			return float64(v.Val)
 		}
 		return date
 	case VT_UNKNOWN:

--- a/vendor/github.com/go-ole/go-ole/variant_date_386.go
+++ b/vendor/github.com/go-ole/go-ole/variant_date_386.go
@@ -1,0 +1,22 @@
+// +build windows,386
+
+package ole
+
+import (
+	"errors"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// GetVariantDate converts COM Variant Time value to Go time.Time.
+func GetVariantDate(value uint64) (time.Time, error) {
+	var st syscall.Systemtime
+	v1 := uint32(value)
+	v2 := uint32(value >> 32)
+	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(v1), uintptr(v2), uintptr(unsafe.Pointer(&st)))
+	if r != 0 {
+		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
+	}
+	return time.Now(), errors.New("Could not convert to time, passing current time.")
+}

--- a/vendor/github.com/go-ole/go-ole/variant_date_amd64.go
+++ b/vendor/github.com/go-ole/go-ole/variant_date_amd64.go
@@ -1,0 +1,20 @@
+// +build windows,amd64
+
+package ole
+
+import (
+	"errors"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// GetVariantDate converts COM Variant Time value to Go time.Time.
+func GetVariantDate(value uint64) (time.Time, error) {
+	var st syscall.Systemtime
+	r, _, _ := procVariantTimeToSystemTime.Call(uintptr(value), uintptr(unsafe.Pointer(&st)))
+	if r != 0 {
+		return time.Date(int(st.Year), time.Month(st.Month), int(st.Day), int(st.Hour), int(st.Minute), int(st.Second), int(st.Milliseconds/1000), time.UTC), nil
+	}
+	return time.Now(), errors.New("Could not convert to time, passing current time.")
+}

--- a/vendor/github.com/go-ole/go-ole/variant_ppc64le.go
+++ b/vendor/github.com/go-ole/go-ole/variant_ppc64le.go
@@ -1,0 +1,12 @@
+// +build ppc64le
+
+package ole
+
+type VARIANT struct {
+	VT         VT      //  2
+	wReserved1 uint16  //  4
+	wReserved2 uint16  //  6
+	wReserved3 uint16  //  8
+	Val        int64   // 16
+	_          [8]byte // 24
+}

--- a/vendor/github.com/shirou/gopsutil/cpu/cpu_windows.go
+++ b/vendor/github.com/shirou/gopsutil/cpu/cpu_windows.go
@@ -23,8 +23,7 @@ type Win32_Processor struct {
 	MaxClockSpeed             uint32
 }
 
-// Win32_PerfFormattedData_Counters_ProcessorInformation stores instance value of the perf counters
-type Win32_PerfFormattedData_Counters_ProcessorInformation struct {
+type win32_PerfRawData_Counters_ProcessorInformation struct {
 	Name                  string
 	PercentDPCTime        uint64
 	PercentIdleTime       uint64
@@ -44,6 +43,10 @@ type Win32_PerfFormattedData_PerfOS_System struct {
 	ProcessorQueueLength uint32
 }
 
+const (
+	win32_TicksPerSecond = 10000000.0
+)
+
 // Times returns times stat per cpu and combined for all CPUs
 func Times(percpu bool) ([]TimesStat, error) {
 	return TimesWithContext(context.Background(), percpu)
@@ -51,7 +54,7 @@ func Times(percpu bool) ([]TimesStat, error) {
 
 func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 	if percpu {
-		return perCPUTimes()
+		return perCPUTimesWithContext(ctx)
 	}
 
 	var ret []TimesStat
@@ -119,17 +122,13 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 
 // PerfInfo returns the performance counter's instance value for ProcessorInformation.
 // Name property is the key by which overall, per cpu and per core metric is known.
-func PerfInfo() ([]Win32_PerfFormattedData_Counters_ProcessorInformation, error) {
-	return PerfInfoWithContext(context.Background())
-}
+func perfInfoWithContext(ctx context.Context) ([]win32_PerfRawData_Counters_ProcessorInformation, error) {
+	var ret []win32_PerfRawData_Counters_ProcessorInformation
 
-func PerfInfoWithContext(ctx context.Context) ([]Win32_PerfFormattedData_Counters_ProcessorInformation, error) {
-	var ret []Win32_PerfFormattedData_Counters_ProcessorInformation
-
-	q := wmi.CreateQuery(&ret, "")
+	q := wmi.CreateQuery(&ret, "WHERE NOT Name LIKE '%_Total'")
 	err := common.WMIQueryWithContext(ctx, q, &ret)
 	if err != nil {
-		return []Win32_PerfFormattedData_Counters_ProcessorInformation{}, err
+		return []win32_PerfRawData_Counters_ProcessorInformation{}, err
 	}
 
 	return ret, err
@@ -152,19 +151,19 @@ func ProcInfoWithContext(ctx context.Context) ([]Win32_PerfFormattedData_PerfOS_
 }
 
 // perCPUTimes returns times stat per cpu, per core and overall for all CPUs
-func perCPUTimes() ([]TimesStat, error) {
+func perCPUTimesWithContext(ctx context.Context) ([]TimesStat, error) {
 	var ret []TimesStat
-	stats, err := PerfInfo()
+	stats, err := perfInfoWithContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, v := range stats {
 		c := TimesStat{
 			CPU:    v.Name,
-			User:   float64(v.PercentUserTime),
-			System: float64(v.PercentPrivilegedTime),
-			Idle:   float64(v.PercentIdleTime),
-			Irq:    float64(v.PercentInterruptTime),
+			User:   float64(v.PercentUserTime) / win32_TicksPerSecond,
+			System: float64(v.PercentPrivilegedTime) / win32_TicksPerSecond,
+			Idle:   float64(v.PercentIdleTime) / win32_TicksPerSecond,
+			Irq:    float64(v.PercentInterruptTime) / win32_TicksPerSecond,
 		}
 		ret = append(ret, c)
 	}

--- a/vendor/github.com/shirou/gopsutil/mem/mem.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem.go
@@ -44,7 +44,7 @@ type VirtualMemoryStat struct {
 
 	// FreeBSD specific numbers:
 	// https://reviews.freebsd.org/D8467
-	Laundry  uint64 `json:"laundry"`
+	Laundry uint64 `json:"laundry"`
 
 	// Linux specific numbers
 	// https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
@@ -57,6 +57,7 @@ type VirtualMemoryStat struct {
 	WritebackTmp   uint64 `json:"writebacktmp"`
 	Shared         uint64 `json:"shared"`
 	Slab           uint64 `json:"slab"`
+	SReclaimable   uint64 `json:"sreclaimable"`
 	PageTables     uint64 `json:"pagetables"`
 	SwapCached     uint64 `json:"swapcached"`
 	CommitLimit    uint64 `json:"commitlimit"`

--- a/vendor/github.com/shirou/gopsutil/mem/mem_linux.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_linux.go
@@ -61,6 +61,8 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 			ret.Shared = t * 1024
 		case "Slab":
 			ret.Slab = t * 1024
+		case "SReclaimable":
+			ret.SReclaimable = t * 1024
 		case "PageTables":
 			ret.PageTables = t * 1024
 		case "SwapCached":
@@ -97,6 +99,9 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 			ret.HugePageSize = t * 1024
 		}
 	}
+
+	ret.Cached += ret.SReclaimable
+
 	if !memavail {
 		ret.Available = ret.Free + ret.Buffers + ret.Cached
 	}

--- a/vendor/github.com/shirou/gopsutil/net/net_linux.go
+++ b/vendor/github.com/shirou/gopsutil/net/net_linux.go
@@ -393,7 +393,11 @@ func statsFromInodes(root string, pid int32, tmap []netConnectionKindType, inode
 		var path string
 		var connKey string
 		var ls []connTmp
-		path = fmt.Sprintf("%s/net/%s", root, t.filename)
+		if pid == 0 {
+			path = fmt.Sprintf("%s/net/%s", root, t.filename)
+		} else {
+			path = fmt.Sprintf("%s/%d/net/%s", root, pid, t.filename)
+		}
 		switch t.family {
 		case syscall.AF_INET, syscall.AF_INET6:
 			ls, err = processInet(path, t, inodes, pid)

--- a/vendor/github.com/shirou/gopsutil/process/process.go
+++ b/vendor/github.com/shirou/gopsutil/process/process.go
@@ -146,6 +146,19 @@ func PidExistsWithContext(ctx context.Context, pid int32) (bool, error) {
 	return false, err
 }
 
+// Background returns true if the process is in background, false otherwise.
+func (p *Process) Background() (bool, error) {
+	return p.BackgroundWithContext(context.Background())
+}
+
+func (p *Process) BackgroundWithContext(ctx context.Context) (bool, error) {
+	fg, err := p.ForegroundWithContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	return !fg, err
+}
+
 // If interval is 0, return difference from last call(non-blocking).
 // If interval > 0, wait interval sec and return diffrence between start and end.
 func (p *Process) Percent(interval time.Duration) (float64, error) {

--- a/vendor/github.com/shirou/gopsutil/process/process_darwin.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_darwin.go
@@ -239,6 +239,25 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 
 	return r[0][0], err
 }
+
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	pid := p.Pid
+	ps, err := exec.LookPath("ps")
+	if err != nil {
+		return false, err
+	}
+	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
+	if err != nil {
+		return false, err
+	}
+	return strings.IndexByte(string(out), '+') != -1, nil
+}
+
 func (p *Process) Uids() ([]int32, error) {
 	return p.UidsWithContext(context.Background())
 }

--- a/vendor/github.com/shirou/gopsutil/process/process_fallback.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_fallback.go
@@ -114,6 +114,13 @@ func (p *Process) Status() (string, error) {
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	return false, common.ErrNotImplementedError
+}
 func (p *Process) Uids() ([]int32, error) {
 	return p.UidsWithContext(context.Background())
 }

--- a/vendor/github.com/shirou/gopsutil/process/process_openbsd.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_openbsd.go
@@ -162,6 +162,23 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 
 	return s, nil
 }
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	pid := p.Pid
+	ps, err := exec.LookPath("ps")
+	if err != nil {
+		return false, err
+	}
+	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
+	if err != nil {
+		return false, err
+	}
+	return strings.IndexByte(string(out), '+') != -1, nil
+}
 func (p *Process) Uids() ([]int32, error) {
 	return p.UidsWithContext(context.Background())
 }

--- a/vendor/github.com/shirou/gopsutil/process/process_windows.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_windows.go
@@ -27,6 +27,10 @@ const (
 var (
 	modpsapi                 = windows.NewLazySystemDLL("psapi.dll")
 	procGetProcessMemoryInfo = modpsapi.NewProc("GetProcessMemoryInfo")
+
+	advapi32                  = windows.NewLazySystemDLL("advapi32.dll")
+	procLookupPrivilegeValue  = advapi32.NewProc("LookupPrivilegeValueW")
+	procAdjustTokenPrivileges = advapi32.NewProc("AdjustTokenPrivileges")
 )
 
 type SystemProcessInformation struct {
@@ -90,8 +94,61 @@ type Win32_Process struct {
 	WorkingSetSize        uint64
 }
 
+type winLUID struct {
+	LowPart  winDWord
+	HighPart winLong
+}
+
+// LUID_AND_ATTRIBUTES
+type winLUIDAndAttributes struct {
+	Luid       winLUID
+	Attributes winDWord
+}
+
+// TOKEN_PRIVILEGES
+type winTokenPriviledges struct {
+	PrivilegeCount winDWord
+	Privileges     [1]winLUIDAndAttributes
+}
+
+type winLong int32
+type winDWord uint32
+
 func init() {
 	wmi.DefaultClient.AllowMissingFields = true
+
+	// enable SeDebugPrivilege https://github.com/midstar/proci/blob/6ec79f57b90ba3d9efa2a7b16ef9c9369d4be875/proci_windows.go#L80-L119
+	handle, err := syscall.GetCurrentProcess()
+	if err != nil {
+		return
+	}
+
+	var token syscall.Token
+	err = syscall.OpenProcessToken(handle, 0x0028, &token)
+	if err != nil {
+		return
+	}
+	defer token.Close()
+
+	tokenPriviledges := winTokenPriviledges{PrivilegeCount: 1}
+	lpName := syscall.StringToUTF16("SeDebugPrivilege")
+	ret, _, _ := procLookupPrivilegeValue.Call(
+		0,
+		uintptr(unsafe.Pointer(&lpName[0])),
+		uintptr(unsafe.Pointer(&tokenPriviledges.Privileges[0].Luid)))
+	if ret == 0 {
+		return
+	}
+
+	tokenPriviledges.Privileges[0].Attributes = 0x00000002 // SE_PRIVILEGE_ENABLED
+
+	procAdjustTokenPrivileges.Call(
+		uintptr(token),
+		0,
+		uintptr(unsafe.Pointer(&tokenPriviledges)),
+		uintptr(unsafe.Sizeof(tokenPriviledges)),
+		0,
+		0)
 }
 
 func Pids() ([]int32, error) {
@@ -177,7 +234,20 @@ func (p *Process) Exe() (string, error) {
 }
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	if p.Pid != 0 { // 0 or null is the current process for CreateToolhelp32Snapshot
+		snap := w32.CreateToolhelp32Snapshot(w32.TH32CS_SNAPMODULE|w32.TH32CS_SNAPMODULE32, uint32(p.Pid))
+		if snap != 0 { // don't report errors here, fallback to WMI instead
+			defer w32.CloseHandle(snap)
+			var me32 w32.MODULEENTRY32
+			me32.Size = uint32(unsafe.Sizeof(me32))
+
+			if w32.Module32First(snap, &me32) {
+				szexepath := windows.UTF16ToString(me32.SzExePath[:])
+				return szexepath, nil
+			}
+		}
+	}
+	dst, err := GetWin32ProcWithContext(ctx, p.Pid)
 	if err != nil {
 		return "", fmt.Errorf("could not get ExecutablePath: %s", err)
 	}
@@ -189,7 +259,7 @@ func (p *Process) Cmdline() (string, error) {
 }
 
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	dst, err := GetWin32ProcWithContext(ctx, p.Pid)
 	if err != nil {
 		return "", fmt.Errorf("could not get CommandLine: %s", err)
 	}
@@ -204,7 +274,7 @@ func (p *Process) CmdlineSlice() ([]string, error) {
 }
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
-	cmdline, err := p.Cmdline()
+	cmdline, err := p.CmdlineWithContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +320,15 @@ func (p *Process) Status() (string, error) {
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
+
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	return false, common.ErrNotImplementedError
+}
+
 func (p *Process) Username() (string, error) {
 	return p.UsernameWithContext(context.Background())
 }
@@ -309,7 +388,7 @@ func (p *Process) Nice() (int32, error) {
 }
 
 func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	dst, err := GetWin32ProcWithContext(ctx, p.Pid)
 	if err != nil {
 		return 0, fmt.Errorf("could not get Priority: %s", err)
 	}
@@ -346,7 +425,7 @@ func (p *Process) IOCounters() (*IOCountersStat, error) {
 }
 
 func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	dst, err := GetWin32ProcWithContext(ctx, p.Pid)
 	if err != nil || len(dst) == 0 {
 		return nil, fmt.Errorf("could not get Win32Proc: %s", err)
 	}
@@ -378,7 +457,7 @@ func (p *Process) NumThreads() (int32, error) {
 }
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	dst, err := GetWin32ProcWithContext(ctx, p.Pid)
 	if err != nil {
 		return 0, fmt.Errorf("could not get ThreadCount: %s", err)
 	}
@@ -456,22 +535,33 @@ func (p *Process) Children() ([]*Process, error) {
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
-	var dst []Win32_Process
-	query := wmi.CreateQuery(&dst, fmt.Sprintf("Where ParentProcessId = %d", p.Pid))
-	err := common.WMIQueryWithContext(ctx, query, &dst)
-	if err != nil {
-		return nil, err
-	}
-
 	out := []*Process{}
-	for _, proc := range dst {
-		p, err := NewProcess(int32(proc.ProcessID))
-		if err != nil {
-			continue
-		}
-		out = append(out, p)
+	snap := w32.CreateToolhelp32Snapshot(w32.TH32CS_SNAPPROCESS, uint32(0))
+	if snap == 0 {
+		return out, windows.GetLastError()
+	}
+	defer w32.CloseHandle(snap)
+	var pe32 w32.PROCESSENTRY32
+	pe32.DwSize = uint32(unsafe.Sizeof(pe32))
+	if w32.Process32First(snap, &pe32) == false {
+		return out, windows.GetLastError()
 	}
 
+	if pe32.Th32ParentProcessID == uint32(p.Pid) {
+		p, err := NewProcess(int32(pe32.Th32ProcessID))
+		if err == nil {
+			out = append(out, p)
+		}
+	}
+
+	for w32.Process32Next(snap, &pe32) {
+		if pe32.Th32ParentProcessID == uint32(p.Pid) {
+			p, err := NewProcess(int32(pe32.Th32ProcessID))
+			if err == nil {
+				out = append(out, p)
+			}
+		}
+	}
 	return out, nil
 }
 

--- a/vendor/github.com/struCoder/pidusage/.gitignore
+++ b/vendor/github.com/struCoder/pidusage/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/struCoder/pidusage/LICENSE
+++ b/vendor/github.com/struCoder/pidusage/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 David 大伟
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/struCoder/pidusage/README.md
+++ b/vendor/github.com/struCoder/pidusage/README.md
@@ -1,0 +1,43 @@
+# pidusage
+Cross-platform process cpu % and memory usage of a PID for golang
+
+Ideas from https://github.com/soyuka/pidusage but just use Golang
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/struCoder/pidusage)](https://goreportcard.com/report/github.com/struCoder/pidusage)
+[![GoDoc](https://godoc.org/github.com/struCoder/pidusage?status.svg)](https://godoc.org/github.com/struCoder/pidusage)
+
+## API
+
+```golang
+import (
+  "os"
+	"github.com/struCoder/pidusage"
+)
+
+func printStat() {
+	sysInfo, err := pidusage.GetStat(os.Process.Pid)
+}
+```
+
+## How it works
+
+A check on the `runtime.GOOS` is done to determine the method to use.
+
+### Linux
+We use `/proc/{pid}/stat` in addition to the the `PAGE_SIZE` and the `CLK_TCK` direclty from `getconf()` command. Uptime comes from `proc/uptime`
+
+Cpu usage is computed by following [those instructions](http://stackoverflow.com/questions/16726779/how-do-i-get-the-total-cpu-usage-of-an-application-from-proc-pid-stat/16736599#16736599). It keeps an history of the current processor time for the given pid so that the computed value gets more and more accurate. Don't forget to do `unmonitor(pid)` so that history gets cleared.
+Cpu usage does not check the child process tree!
+
+Memory result is representing the RSS (resident set size) only by doing `rss*pagesize`, where `pagesize` is the result of `getconf PAGE_SIZE`.
+
+### On darwin, freebsd, solaris
+We use a fallback with the `ps -o pcpu,rss -p PID` command to get the same informations.
+
+Memory usage will also display the RSS only, process cpu usage might differ from a distribution to another. Please check the correspoding `man ps` for more insights on the subject.
+
+### On AIX
+AIX is tricky because I have no AIX test environement, at the moment we use: `ps -o pcpu,rssize -p PID` but `/proc` results should be more accurate! If you're familiar with the AIX environment and know how to get the same results as we've got with Linux systems.
+
+### Windows
+Next version will support

--- a/vendor/github.com/struCoder/pidusage/pidusage.go
+++ b/vendor/github.com/struCoder/pidusage/pidusage.go
@@ -1,0 +1,155 @@
+package pidusage
+
+import (
+	"errors"
+	"io/ioutil"
+	"math"
+	"os/exec"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// SysInfo will record cpu and memory data
+type SysInfo struct {
+	CPU    float64
+	Memory float64
+}
+
+// Stat will store CUP time struct
+type Stat struct {
+	utime  float64
+	stime  float64
+	cutime float64
+	cstime float64
+	start  float64
+	rss    float64
+	uptime float64
+}
+
+type fn func(int) (*SysInfo, error)
+
+var fnMap map[string]fn
+var platform string
+var history map[int]Stat
+var eol string
+
+func wrapper(statType string) func(pid int) (*SysInfo, error) {
+	return func(pid int) (*SysInfo, error) {
+		return stat(pid, statType)
+	}
+}
+func init() {
+	platform = runtime.GOOS
+	eol = "\n"
+	if strings.Index(platform, "win") == 0 {
+		platform = "win"
+		eol = "\r\n"
+	}
+	history = make(map[int]Stat)
+	fnMap = make(map[string]fn)
+	fnMap["darwin"] = wrapper("ps")
+	fnMap["sunos"] = wrapper("ps")
+	fnMap["freebsd"] = wrapper("ps")
+	fnMap["aix"] = wrapper("ps")
+	fnMap["linux"] = wrapper("proc")
+	fnMap["netbsd"] = wrapper("proc")
+	fnMap["win"] = wrapper("win")
+}
+func formatStdOut(stdout []byte, userfulIndex int) []string {
+	infoArr := strings.Split(string(stdout), eol)[userfulIndex]
+	ret := strings.Fields(infoArr)
+	return ret
+}
+
+func parseFloat(val string) float64 {
+	floatVal, _ := strconv.ParseFloat(val, 64)
+	return floatVal
+}
+
+func stat(pid int, statType string) (*SysInfo, error) {
+	sysInfo := &SysInfo{}
+	_history := history[pid]
+	if statType == "ps" {
+		args := "-o pcpu,rss -p"
+		if platform == "aix" {
+			args = "-o pcpu,rssize -p"
+		}
+		stdout, _ := exec.Command("ps", args, strconv.Itoa(pid)).Output()
+		ret := formatStdOut(stdout, 1)
+		if len(ret) == 0 {
+			return sysInfo, errors.New("can not foud this pid: " + strconv.Itoa(pid))
+		}
+		sysInfo.CPU = parseFloat(ret[0])
+		sysInfo.Memory = parseFloat(ret[1]) * 1024
+	} else if statType == "proc" {
+		// default clkTck and pageSize
+		var clkTck float64 = 100
+		var pageSize float64 = 4096
+
+		uptimeFileBytes, err := ioutil.ReadFile(path.Join("/proc", "uptime"))
+		uptime := parseFloat(strings.Split(string(uptimeFileBytes), " ")[0])
+
+		clkTckStdout, err := exec.Command("getconf", "CLK_TCK").Output()
+		if err == nil {
+			clkTck = parseFloat(formatStdOut(clkTckStdout, 0)[0])
+		}
+
+		pageSizeStdout, err := exec.Command("getconf", "PAGESIZE").Output()
+		if err == nil {
+			pageSize = parseFloat(formatStdOut(pageSizeStdout, 0)[0])
+		}
+
+		procStatFileBytes, err := ioutil.ReadFile(path.Join("/proc", strconv.Itoa(pid), "stat"))
+		splitAfter := strings.SplitAfter(string(procStatFileBytes), ")")
+
+		if len(splitAfter) == 0 || len(splitAfter) == 1 {
+			return sysInfo, errors.New("can not foud this pid: " + strconv.Itoa(pid))
+		}
+		infos := strings.Split(splitAfter[1], " ")
+		stat := &Stat{
+			utime:  parseFloat(infos[12]),
+			stime:  parseFloat(infos[13]),
+			cutime: parseFloat(infos[14]),
+			cstime: parseFloat(infos[15]),
+			start:  parseFloat(infos[20]) / clkTck,
+			rss:    parseFloat(infos[22]),
+			uptime: uptime,
+		}
+
+		_stime := 0.0
+		_utime := 0.0
+		if _history.stime != 0 {
+			_stime = _history.stime
+		}
+
+		if _history.utime != 0 {
+			_utime = _history.utime
+		}
+		total := stat.stime - _stime + stat.utime - _utime
+		total = total / clkTck
+
+		seconds := stat.start - uptime
+		if _history.uptime != 0 {
+			seconds = uptime - _history.uptime
+		}
+
+		seconds = math.Abs(seconds)
+		if seconds == 0 {
+			seconds = 1
+		}
+
+		history[pid] = *stat
+		sysInfo.CPU = (total / seconds) * 100
+		sysInfo.Memory = stat.rss * pageSize
+	}
+	return sysInfo, nil
+
+}
+
+// GetStat will return current system CPU and memory data
+func GetStat(pid int) (*SysInfo, error) {
+	sysInfo, err := fnMap[platform](pid)
+	return sysInfo, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,8 @@
-# github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
+# github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 github.com/StackExchange/wmi
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
-# github.com/go-ole/go-ole v1.2.1
+# github.com/go-ole/go-ole v1.2.4
 github.com/go-ole/go-ole
 github.com/go-ole/go-ole/oleutil
 # github.com/hashicorp/hcl v1.0.0
@@ -28,7 +28,7 @@ github.com/magiconair/properties
 github.com/mitchellh/mapstructure
 # github.com/pelletier/go-toml v1.2.0
 github.com/pelletier/go-toml
-# github.com/shirou/gopsutil v2.18.10+incompatible
+# github.com/shirou/gopsutil v2.18.12+incompatible
 github.com/shirou/gopsutil/process
 github.com/shirou/gopsutil/cpu
 github.com/shirou/gopsutil/host
@@ -52,6 +52,8 @@ github.com/spf13/jwalterweatherman
 github.com/spf13/pflag
 # github.com/spf13/viper v1.2.1
 github.com/spf13/viper
+# github.com/struCoder/pidusage v0.1.2
+github.com/struCoder/pidusage
 # github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
 github.com/tcnksm/go-input
 # golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869


### PR DESCRIPTION
Related to #18 

- [x] Suppress the process index and start with the PID directly to simplify the line, start with "└" for the process to make it look like a child of the application line
- [x] All numbers be padded on a fixed size to preserve alignment
- [x] Process phase only displayed if it's different from application phase to save space, at the end of the line, in orange
- [ ] Uptime /w 1 space between number and letter, only pad the whole string to maintain alignment -> need this MR validated before do these changes https://github.com/dimelo/puma-helper/pull/20/files
- [x] Last checkin disabled if there's an issue (> 10 sec)
- [x] Delete headers lines
- [x] Remove the number of workers per apps
- [x] No digit in memory
- [x] Throw errors at the end of the output
- [x] MiB to M
- [x] Active Threads / Threads to Load
- [x] Sort workers by uptime
- [x] Add queuing in worker line
- [x] Better current CPU usage based on PID

<img width="492" alt="Screenshot 2019-06-07 at 14 15 40" src="https://user-images.githubusercontent.com/7628998/59103354-e9787f80-892e-11e9-9507-e57e560f6a98.png">
